### PR TITLE
:arrow_up: Bump logback-classic to 1.5.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>1.5.17</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request includes a small change to the `pom.xml` file. The change specifies the version of the `logback-classic` dependency to `1.5.17`.