### PR TITLE
Extend copyright to 2025

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Stefan Haun and contributors
+Copyright 2022-2025 Stefan Haun and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ If possible, please stick to the following guidelines:
 
 ## License
 
-[MIT](LICENSE.txt) © 2022 Stefan Haun and contributors
+[MIT](LICENSE.txt) © 2022-2025 Stefan Haun and contributors


### PR DESCRIPTION
This pull request includes updates to the copyright year.

* [`LICENSE.txt`](diffhunk://#diff-d0ed4cc3fb70489fe51c7e0ac180cba2a7472124f9f9e9ae67b01a37fbd580b7L1-R1): Updated the copyright year from 2022 to 2022-2025.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R102): Updated the license year from 2022 to 2022-2025.