### PR TITLE
:arrow_up: Bump cleanURI-site-implementations to 0.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-site-implementations</artifactId>
-      <version>0.3.1</version>
+      <version>0.3.2</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request includes a small change to the `pom.xml` file. The change updates the version of the `cleanURI-site-implementations` dependency from `0.3.1` to `0.3.2`.

With this update, a bug in the Reichelt URI extractor and the Ebay extraction are fixed.